### PR TITLE
Add Windows service start and stop scripts

### DIFF
--- a/ibind/service/scripts/start_service.bat
+++ b/ibind/service/scripts/start_service.bat
@@ -1,0 +1,47 @@
+@echo off
+REM start_service.bat - Production startup script
+
+setlocal enabledelayedexpansion
+
+echo Starting IBKR RESTful Web Service...
+
+REM Check if required environment variables are set
+set "missing=0"
+for %%V in (IBIND_ACCOUNT_ID IBIND_CONSUMER_KEY IBIND_CONSUMER_SECRET IBIND_ACCESS_TOKEN IBIND_ACCESS_TOKEN_SECRET) do (
+    if not defined %%V (
+        echo Error: Required environment variable %%V is not set
+        set "missing=1"
+    )
+)
+
+if not "!missing!"=="0" (
+    echo Please check your environment configuration
+    exit /b 1
+)
+
+REM Set default values
+if not defined IBKR_SERVICE_HOST set "IBKR_SERVICE_HOST=127.0.0.1"
+if not defined IBKR_SERVICE_PORT set "IBKR_SERVICE_PORT=8000"
+if not defined IBKR_SERVICE_LOG_LEVEL set "IBKR_SERVICE_LOG_LEVEL=info"
+
+REM Create logs directory if it doesn't exist
+if not exist logs mkdir logs
+
+REM Check if we're in development or production
+if /I "%1"=="dev" (
+    echo Starting in development mode with auto-reload...
+    python main.py --host %IBKR_SERVICE_HOST% --port %IBKR_SERVICE_PORT% --reload --log-level debug
+) else if /I "%1"=="prod" (
+    echo Starting in production mode with gunicorn...
+    where gunicorn >nul 2>&1
+    if errorlevel 1 (
+        echo Gunicorn not found. Installing...
+        pip install gunicorn
+    )
+    gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind %IBKR_SERVICE_HOST%:%IBKR_SERVICE_PORT% --log-level %IBKR_SERVICE_LOG_LEVEL%
+) else (
+    echo Starting in standard mode...
+    python main.py --host %IBKR_SERVICE_HOST% --port %IBKR_SERVICE_PORT% --log-level %IBKR_SERVICE_LOG_LEVEL%
+)
+
+endlocal

--- a/ibind/service/scripts/stop_service.bat
+++ b/ibind/service/scripts/stop_service.bat
@@ -1,0 +1,29 @@
+@echo off
+REM stop_service.bat - Stop the service gracefully
+
+setlocal enabledelayedexpansion
+
+echo Stopping IBKR Web Service...
+
+for /f "tokens=2 delims== " %%P in ('wmic process where "CommandLine like '%%main.py%%' or CommandLine like '%%gunicorn%%main:app%%'" get ProcessId /value ^| find "="') do (
+    set "PIDS=!PIDS! %%P"
+)
+
+if not defined PIDS (
+    echo No IBKR Web Service processes found
+) else (
+    echo Found processes: !PIDS!
+    for %%P in (!PIDS!) do (
+        echo Stopping process %%P...
+        taskkill /PID %%P /T >nul 2>&1
+        timeout /t 2 >nul
+        tasklist /FI "PID eq %%P" | find "%%P" >nul
+        if not errorlevel 1 (
+            echo Force killing process %%P...
+            taskkill /PID %%P /T /F >nul 2>&1
+        )
+    )
+    echo IBKR Web Service stopped
+)
+
+endlocal


### PR DESCRIPTION
## Summary
- add `start_service.bat` to launch the IBKR RESTful web service on Windows
- add `stop_service.bat` to terminate running service processes

## Testing
- `git fetch --all`
- `IBIND_ACCOUNT_ID=1 IBIND_CONSUMER_KEY=a IBIND_CONSUMER_SECRET=b IBIND_ACCESS_TOKEN=c IBIND_ACCESS_TOKEN_SECRET=d bash scripts/start_service.sh dev` *(fails: AssertionError: Path parameters cannot have a default value)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'test_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6893bc16600c8324a1611c30fb096bc0